### PR TITLE
Add Proxy functionality to Pingdom API Client

### DIFF
--- a/src/Silverstripe/Pingdom/Api/Client.php
+++ b/src/Silverstripe/Pingdom/Api/Client.php
@@ -28,6 +28,20 @@ class Client
     private $gzip;
 
     /**
+     * Proxy Host value for curl.
+     *
+     * @var string
+     */
+    private $proxyHost;
+
+    /**
+     * Proxy port value for curl.
+     *
+     * @var int
+     */
+    private $proxyPort;
+
+    /**
      * @param string $api_key The Pingdom API key
      * @param bool   $gzip    false if responses from Pingdom should not use gzip compression
      */
@@ -445,6 +459,18 @@ class Client
     }
 
     /**
+     * Set curl proxy settings.
+     *
+     * @param string $host Proxy hostname/IP
+     * @param int    $port Proxy port
+     */
+    public function setProxy(string $host, int $port)
+    {
+        $this->proxyHost = $host;
+        $this->proxyPort = $port;
+    }
+
+    /**
      * Makes a request to the Pingdom REST API.
      *
      * @param string $method     The HTTP request method e.g. GET, POST, and PUT.
@@ -491,6 +517,12 @@ class Client
         curl_setopt($handle, \CURLOPT_TIMEOUT, 10);
         $gzip = !empty($this->gzip) ? 'gzip' : '';
         curl_setopt($handle, \CURLOPT_ENCODING, $gzip);
+
+        // Set proxy configuration
+        if ($this->proxyHost && $this->proxyPort) {
+            curl_setopt($ch, \CURLOPT_PROXY, $this->proxyHost);
+            curl_setopt($ch, \CURLOPT_PROXYPORT, $this->proxyPort);
+        }
 
         $response = curl_exec($handle);
         if (curl_errno($handle) > 0) {

--- a/test/Silverstripe/Test/Pingdom/PingdomApi.php
+++ b/test/Silverstripe/Test/Pingdom/PingdomApi.php
@@ -238,7 +238,21 @@ class PingdomApi extends TestCase
             'array' => [],
         ];
 
-        $this->pingdom->ensureParameters($parameters, __METHOD__);
+        // Assert null as a function that expects nothing should return null
+        // Reference: https://stackoverflow.com/a/45850982
+        $this->assertNull($this->pingdom->ensureParameters($parameters, __METHOD__));
+    }
+
+    /**
+     * Test setProxy() stores proxy settings to be consumed by curl.
+     */
+    public function testSetProxy()
+    {
+        $this->pingdom->setProxy('test', 1234);
+
+        // Ensure private attributes are set as expected.
+        $this->assertAttributeEquals('test', 'proxyHost', $this->pingdom);
+        $this->assertAttributeEquals(1234, 'proxyPort', $this->pingdom);
     }
 
     /**


### PR DESCRIPTION
 - `setProxy` method added to Client API
 - `testMissingParametersEnsureParametersEmptyValues` phpunit test fixed
 - `testSetProxy` phpunit test added