### PR TITLE
Hotfix: Fix incorrect handle variable in Client

### DIFF
--- a/src/Silverstripe/Pingdom/Api/Client.php
+++ b/src/Silverstripe/Pingdom/Api/Client.php
@@ -520,8 +520,8 @@ class Client
 
         // Set proxy configuration
         if ($this->proxyHost && $this->proxyPort) {
-            curl_setopt($ch, \CURLOPT_PROXY, $this->proxyHost);
-            curl_setopt($ch, \CURLOPT_PROXYPORT, $this->proxyPort);
+            curl_setopt($handle, \CURLOPT_PROXY, $this->proxyHost);
+            curl_setopt($handle, \CURLOPT_PROXYPORT, $this->proxyPort);
         }
 
         $response = curl_exec($handle);


### PR DESCRIPTION
Missed bug in latest changes where incorrect handler variables was used. Was not picked up in testing as test cluster does not use Pingdom integration.